### PR TITLE
Fixes typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
  
  
 ## Files in the folder
-### In folder you see 6 files (except reabme.md file)
+### In folder you see 6 files (except README.md file)
 * <b>There are 5 libraries in this folder you need to save these libraries in the raspberry pi pico,
      4 libraries of sensors and 1 library of lcd display
   * <b> sgp40.py 


### PR DESCRIPTION
- `reabme.md` to `README.md` - fixes typo and uses uppercase in the file name, to match the repo structure.